### PR TITLE
feat: set sourceComponentId on component

### DIFF
--- a/src/order/orderData/item/component/component.php
+++ b/src/order/orderData/item/component/component.php
@@ -18,6 +18,7 @@ class OneFlowComponent extends OneFlowBase	{
 	 */
 	public function init()      {
 		$this->__addProperty("componentId");
+		$this->__addProperty("sourceComponentId");
 		$this->__addProperty("type");
 		$this->__addProperty("code");
 		$this->__addProperty("path");
@@ -267,6 +268,17 @@ class OneFlowComponent extends OneFlowBase	{
      */
     public function setComponentId($componentId)	{
 	    $this->componentId = $componentId;
+    }
+
+    /**
+     * setSourceComponentId function.
+     *
+     * @access public
+     * @param mixed $sourceComponentId
+     * @return void
+     */
+    public function setSourceComponentId($sourceComponentId)	{
+	    $this->sourceComponentId = $sourceComponentId;
     }
 
     /**

--- a/tests/order/orderTest.php
+++ b/tests/order/orderTest.php
@@ -32,6 +32,7 @@ final class OneflowOrderTest extends TestCase
 		]);
 
 		$component = $item->newComponent('componentCode');
+		$component->setSourceComponentId('my-source-component-id');
 		$component->setFetchUrl('http://site.com/file.pdf');
 		$component->setLocalFile(false);
 		$component->setBarcode('customComponentBarcode');
@@ -151,6 +152,7 @@ final class OneflowOrderTest extends TestCase
 		$this->assertEquals(1, count($outputItem->components));
 		$outputComponent = $outputItem->components[0];
 		$this->assertEquals('componentCode', $outputComponent->code);
+		$this->assertEquals('my-source-component-id', $outputComponent->sourceComponentId);
 		$this->assertEquals('http://site.com/file.pdf', $outputComponent->path);
 		$this->assertEquals('customComponentBarcode', $outputComponent->barcode);
 		$this->assertEquals(true, $outputComponent->fetch);


### PR DESCRIPTION
Fixes https://github.com/HPInc/oneflow-sdk-php/issues/35

Adds a method to be able to set the `sourceComponentId` on the component object.