### PR TITLE
Allow dynamic properties for PHP 8.2 support

### DIFF
--- a/src/OneflowSDK.php
+++ b/src/OneflowSDK.php
@@ -35,6 +35,7 @@ $loader = new OneFlowSDKLoader();
 /**
  * OneflowSDK class.
  */
+#[AllowDynamicProperties]
 class OneflowSDK {
 
 	protected $url;

--- a/src/base.php
+++ b/src/base.php
@@ -15,6 +15,7 @@ class OneFlow {
 /**
  * OneFlowBase class.
  */
+#[AllowDynamicProperties]
 class OneFlowBase	{
 
 	private $__children = Array();


### PR DESCRIPTION
PHP 8.2 throws warnings when dynamic properties are used in classes. In order to suppress those warnings the #[AllowDynamicProperties] attribute must be included before classes that use them. I have added these to the two classes that I can see that are using dynamic attributes. There may be others.