### PR TITLE
Fix: decode url path before sign

### DIFF
--- a/src/OneflowSDK.php
+++ b/src/OneflowSDK.php
@@ -431,7 +431,7 @@ class OneflowSDK {
 	 * @return string
 	 */
 	private function token($method, $path, $timestamp){
-		$stringToSign = strtoupper($method) . ' ' . $path . ' ' . $timestamp;
+		$stringToSign = strtoupper($method) . ' ' . urldecode($path) . ' ' . $timestamp;
 		return $this->key . ':' . hash_hmac('sha256', $stringToSign, $this->secret);
 	}
 


### PR DESCRIPTION
* Decode url path in signature to support url's with percent encoded characters